### PR TITLE
Fix: Ensure all documents are ingested and queried correctly.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,13 +6,13 @@ import { askQuestion } from "./lib/askQuestion";
 import { ChromaClient } from "chromadb";
 
 (async () => {
-  await createCollection("new_collection"); // run once
+  await createCollection("deal_versions"); // run once
   const rows = await db.query(
     "SELECT * FROM cdm_plan_data_versions where division_id = 4 and ad_date = '04-MAR-2020'"
   );
   console.log(rows);
-  rows.rows.forEach((row, index) => {
-    addDocument(
+  for (const [index, row] of rows.rows.entries()) {
+    await addDocument(
       {
         pageContent: `${row.wh_item_code} has a Vendor deal ${row.deal_type_name} from ${row.deal_start_date} to ${row.deal_end_date} with Deal Rate of ${row.deal_rate} and a customer deal ${row.customer_deal_type_name} from ${row.reflect_start_date} to ${row.reflect_end_date} with rate of ${row.reflect_rate} for and ad date of ${row.ad_date}`,
         metadata: {
@@ -21,9 +21,9 @@ import { ChromaClient } from "chromadb";
         id: row.wh_item_code,
       },
       index,
-      "new_collection"
+      "deal_versions"
     );
-  });
+  }
   //   addDocument({
   //     pageContent:
   //       "Venkatesh is a Sr. Software Engineer woks at CloudIO Inc. from 13years",
@@ -32,38 +32,15 @@ import { ChromaClient } from "chromadb";
   // await askQuestion(
   //   "what is the average deal rate? on how many deals you did the average?"
   // );
+
+  await getCollectionStats("deal_versions");
+  await askQuestion(
+    "what is the average deal rate? on how many deals you did the average?"
+  );
 })();
 
-// async function getCollectionStats(name: string) {
-//   const res = await fetch(`http://localhost:8000/api/v1/collections/${name}`);
-//   const data = await res.json();
-//   console.log(`✅ Collection "${name}" contains ${data?.size || 0} documents`);
-// }
-
-// getCollectionStats("deal_versions");
-// async function getCollectionStats(name: string) {
-//   const client = new ChromaClient({
-//     path: "http://localhost:8000",
-//   });
-//
-//   const collections = await client.getCollection({ name: "deal_versions" });
-//     path: "http://localhost:8000",
-//   });
-
-//   const collections = await client.getCollection({ name: "deal_versions" });
-
-//   console.log(await collections?.count());
-//   // const collections = await client.listCollections();
-//   // console.log(collections);
-// }
-// getCollectionStats("deal_versions");
-
-// ...existing code...
 async function getCollectionStats(name: string) {
   const res = await fetch(`http://localhost:8000/api/v1/collections/${name}`);
   const data = await res.json();
   console.log(`✅ Collection "${name}" contains ${data?.size || 0} documents`);
 }
-
-getCollectionStats("deal_versions");
-// ...existing code...

--- a/lib/askQuestion.ts
+++ b/lib/askQuestion.ts
@@ -8,7 +8,7 @@ import "dotenv/config";
 const CHROMA_URL = "http://localhost:8000";
 const COLLECTION_NAME = "deal_versions";
 
-export const askQuestion = async (question: string) => {
+export const askQuestion = async (question: string, kDocs?: number) => {
   const embeddings = new OpenAIEmbeddings();
 
   const vectorstore = await Chroma.fromExistingCollection(embeddings, {
@@ -16,7 +16,7 @@ export const askQuestion = async (question: string) => {
     url: CHROMA_URL,
   });
 
-  const docs = await vectorstore.similaritySearch(question, 20);
+  const docs = await vectorstore.similaritySearch(question, kDocs ?? 50);
   const context = docs.map((doc) => doc.pageContent).join("\n\n");
 
   const llm = new ChatOpenAI({


### PR DESCRIPTION
This commit addresses an issue where not all documents from Postgres were being effectively utilized in ChromaDB for Q&A tasks.

Key changes:
- Standardized ChromaDB collection name to "deal_versions" across all operations (creation, insertion, querying, stats).
- Ensured proper asynchronous handling during document insertion into ChromaDB by switching from forEach to an awaited for...of loop in index.ts.
- Made the number of documents retrieved by similaritySearch in askQuestion.ts configurable (defaulting to 50) instead of a hardcoded 20.
- Cleaned up and ensured getCollectionStats in index.ts correctly reports document count after ingestion.
- Re-enabled the askQuestion call in index.ts for testing the end-to-end flow.

These changes should ensure more reliable data ingestion and allow your Q&A system to leverage a larger, more accurate set of documents.